### PR TITLE
Fix req.version passed as integer

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function getVersion(req) {
          version = req.headers['accept-version'];
       }
    } else {
-      version = req.version;
+      version = String(req.version);
    }
    return version;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-routes-versioning",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js module provides versioning for expressjs routes/api",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -154,4 +154,15 @@ describe('routes versioning', function() {
                assert.ok(version2Spy.calledOnce);
                assert.ok(version2Spy.calledWith(req, res, next));
             });
+    it('when version provided as integer, version should cast to string',
+      function() {
+         var version1Spy = sinon.spy();
+         var middleware = routesVersioning({
+            "1": version1Spy,
+         });
+         req.version = 1;
+         middleware(req, res, next);
+         assert.ok(version1Spy.calledOnce);
+         assert.ok(version1Spy.calledWith(req, res, next));
+      });
 });


### PR DESCRIPTION
Adds a test and casts to string the any self assigned `req.version` which might be set as an integer/float.

Fixes #3 